### PR TITLE
Implement temp client banning on failed requests

### DIFF
--- a/internal/prometheus/node.go
+++ b/internal/prometheus/node.go
@@ -21,6 +21,7 @@ type collectNodeResponse struct {
 
 func (c *Collector) collectNode(ch chan<- prometheus.Metric, node proxmox.GetNodesData, resultChan chan<- collectNodeResponse, wg *sync.WaitGroup) {
 	defer wg.Done()
+	defer logger.Logger.Debug("finished requests for node data", "node", node.Node)
 	var resp collectNodeResponse
 
 	// Collect metrics that just need node data

--- a/internal/proxmox/nodes.go
+++ b/internal/proxmox/nodes.go
@@ -23,14 +23,25 @@ func GetNodes() (*proxmox.GetNodesResponse, error) {
 
 	// Make request if not found in cache
 	var err error
-	for _, c := range clients {
-		nodes, _, err = c.Nodes.GetNodes()
+	for name, c := range clients {
+		// Check if client was banned, skip if is
+		if c.banned {
+			continue
+		}
+
+		nodes, _, err = c.client.Nodes.GetNodes()
 		if err == nil {
 			break
+		} else {
+			banClient(name, c)
 		}
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if nodes == nil {
+		return nil, fmt.Errorf("request to get node list was not successful. It's possible all clients are banned")
 	}
 
 	// Update cache
@@ -54,14 +65,25 @@ func GetNodeStatus(name string) (*proxmox.GetNodeStatusResponse, error) {
 
 	// Make request if not found in cache
 	var err error
-	for _, c := range clients {
-		node, _, err = c.Nodes.GetNodeStatus(name)
+	for clientName, c := range clients {
+		// Check if client was banned, skip if is
+		if c.banned {
+			continue
+		}
+
+		node, _, err = c.client.Nodes.GetNodeStatus(name)
 		if err == nil {
 			break
+		} else {
+			banClient(clientName, c)
 		}
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if node == nil {
+		return nil, fmt.Errorf("request to get node status was not successful. It's possible all clients are banned")
 	}
 
 	// Update cache
@@ -85,14 +107,25 @@ func GetNodeQemu(name string) (*proxmox.GetNodeQemuResponse, error) {
 
 	// Make request if not found in cache
 	var err error
-	for _, c := range clients {
-		vms, _, err = c.Nodes.GetNodeQemu(name)
+	for clientName, c := range clients {
+		// Check if client was banned, skip if is
+		if c.banned {
+			continue
+		}
+
+		vms, _, err = c.client.Nodes.GetNodeQemu(name)
 		if err == nil {
 			break
+		} else {
+			banClient(clientName, c)
 		}
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if vms == nil {
+		return nil, fmt.Errorf("request to get node VMs was not successful. It's possible all clients are banned")
 	}
 
 	// Update per-node cache since we have it
@@ -116,14 +149,25 @@ func GetNodeLxc(name string) (*proxmox.GetNodeLxcResponse, error) {
 
 	// Make request if not found in cache
 	var err error
-	for _, c := range clients {
-		lxcs, _, err = c.Nodes.GetNodeLxc(name)
+	for clientName, c := range clients {
+		// Check if client was banned, skip if is
+		if c.banned {
+			continue
+		}
+
+		lxcs, _, err = c.client.Nodes.GetNodeLxc(name)
 		if err == nil {
 			break
+		} else {
+			banClient(clientName, c)
 		}
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if lxcs == nil {
+		return nil, fmt.Errorf("request to get node LXCs was not successful. It's possible all clients are banned")
 	}
 
 	// Update per-node cache since we have it
@@ -147,14 +191,25 @@ func GetNodeDisksList(name string) (*proxmox.GetNodeDisksListResponse, error) {
 
 	// Make request if not found in cache
 	var err error
-	for _, c := range clients {
-		disks, _, err = c.Nodes.GetNodeDisksList(name)
+	for clientName, c := range clients {
+		// Check if client was banned, skip if is
+		if c.banned {
+			continue
+		}
+
+		disks, _, err = c.client.Nodes.GetNodeDisksList(name)
 		if err == nil {
 			break
+		} else {
+			banClient(clientName, c)
 		}
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if disks == nil {
+		return nil, fmt.Errorf("request to get node disks was not successful. It's possible all clients are banned")
 	}
 
 	// Update per-node cache since we have it
@@ -178,14 +233,25 @@ func GetNodeCertificatesInfo(name string) (*proxmox.GetNodeCertificatesInfoRespo
 
 	// Make request if not found in cache
 	var err error
-	for _, c := range clients {
-		certs, _, err = c.Nodes.GetNodeCertificatesInfo(name)
+	for clientName, c := range clients {
+		// Check if client was banned, skip if is
+		if c.banned {
+			continue
+		}
+
+		certs, _, err = c.client.Nodes.GetNodeCertificatesInfo(name)
 		if err == nil {
 			break
+		} else {
+			banClient(clientName, c)
 		}
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if certs == nil {
+		return nil, fmt.Errorf("request to get node certificates was not successful. It's possible all clients are banned")
 	}
 
 	// Update per-node cache since we have it
@@ -209,14 +275,25 @@ func GetNodeStorage(name string) (*proxmox.GetNodeStorageResponse, error) {
 
 	// Make request if not found in cache
 	var err error
-	for _, c := range clients {
-		store, _, err = c.Nodes.GetNodeStorage(name)
+	for clientName, c := range clients {
+		// Check if client was banned, skip if is
+		if c.banned {
+			continue
+		}
+
+		store, _, err = c.client.Nodes.GetNodeStorage(name)
 		if err == nil {
 			break
+		} else {
+			banClient(clientName, c)
 		}
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if store == nil {
+		return nil, fmt.Errorf("request to get node storage was not successful. It's possible all clients are banned")
 	}
 
 	// Update per-node cache since we have it


### PR DESCRIPTION
For https://github.com/Starttoaster/proxmox-exporter/issues/35

**Problem statement**: 
Prometheus needs quick exporter page loads for its scrape intervals, and attempting to load these metrics from a Proxmox server that is down can have the consequence of drastically slowing down page loads while waiting for the failed requests to that client to time out.

**Proposed solution**: 
When a request fails against a particular client in the clients list, that client should be temporarily banned. A separate goroutine should run to inspect current bans, make a request against the Proxmox server, see if it succeeds, and unbans the client if the request succeeded. All API requests made for the exporter should check if the client they picked out at random was banned, and skip it if so.

**Potential problems**:
- The first Prometheus scrape interval after a Proxmox host goes down, this exporter won't have banned the down client yet. So the first scrape interval that a Proxmox server is down for will still probably not get picked up by Prometheus. But all scrape intervals after that first one should succeed again. We could proactively ban clients on an interval, but Prometheus's scrape interval might beat us to it and find the down client first anyway.
- If a request made by this exporter 404's, this banning mechanism as written here will ban the client. It would probably be better to only ban the client on 500+ status code responses, but this exporter doesn't accept human inputs for node names and such anyway, so a 404 shouldn't happen. 