### PR TITLE
Add support for server-addr

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ docker run --name proxmox-exporter \
 -e PROXMOX_EXPORTER_PROXMOX_TOKEN='redacted-token' \
 -e PROXMOX_EXPORTER_PROXMOX_TOKEN_ID='redacted-token-id' \
 -e PROXMOX_EXPORTER_SERVER_PORT='8080' \
+-e PROXMOX_EXPORTER_SERVER_ADDR='0.0.0.0' \
 ghcr.io/starttoaster/proxmox-exporter:latest
 ```
 
@@ -139,6 +140,7 @@ PROXMOX_EXPORTER_PROXMOX_ENDPOINTS="https://x:8006/,https://y:8006/,https://z:80
 PROXMOX_EXPORTER_PROXMOX_TOKEN="redacted-token"
 PROXMOX_EXPORTER_PROXMOX_TOKEN_ID="redacted-token-id"
 PROXMOX_EXPORTER_SERVER_PORT=8080
+PROXMOX_EXPORTER_SERVER_ADDR=0.0.0.0
 ```
 
 ## Grafana

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Create http server
-		m, err := http.NewServer(uint16(viper.GetUint("server-port")))
+		m, err := http.NewServer(string(viper.GetString("server-addr")), uint16(viper.GetUint("server-port")))
 		if err != nil {
 			log.Logger.Error(err.Error())
 			os.Exit(1)
@@ -61,6 +61,7 @@ func init() {
 	viper.AutomaticEnv()
 
 	rootCmd.PersistentFlags().String("log-level", "info", "The log-level for the application, can be one of info, warn, error, debug.")
+	rootCmd.PersistentFlags().String("server-addr", "0.0.0.0", "The address on which the exporter listens")
 	rootCmd.PersistentFlags().Uint16("server-port", 8080, "The port the metrics server binds to.")
 	rootCmd.PersistentFlags().String("proxmox-endpoints", "", "The Proxmox API endpoint, you can pass in multiple endpoints separated by commas (ex: https://localhost:8006/)")
 	rootCmd.PersistentFlags().String("proxmox-token-id", "", "Proxmox API token ID")
@@ -68,6 +69,12 @@ func init() {
 	rootCmd.PersistentFlags().Bool("proxmox-api-insecure", false, "Whether or not this client should accept insecure connections to Proxmox (default: false)")
 
 	err := viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	if err != nil {
+		log.Logger.Error(err.Error())
+		os.Exit(1)
+	}
+
+	err = viper.BindPFlag("server-addr", rootCmd.PersistentFlags().Lookup("server-addr"))
 	if err != nil {
 		log.Logger.Error(err.Error())
 		os.Exit(1)

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -15,12 +15,14 @@ import (
 
 // Server is the config for the http server
 type Server struct {
+	addr string
 	port uint16
 }
 
 // NewServer returns a new instance of the http server
-func NewServer(port uint16) (*Server, error) {
+func NewServer(addr string, port uint16) (*Server, error) {
 	server := &Server{
+		addr: addr,
 		port: port,
 	}
 
@@ -29,7 +31,7 @@ func NewServer(port uint16) (*Server, error) {
 
 // StartServer starts the metrics server
 func (s *Server) StartServer() error {
-	log.Logger.Info("Starting server", "port", s.port)
+	log.Logger.Info("Starting server", "addr", s.addr, "port", s.port)
 
 	// Create new router with healthcheck handler
 	r := mux.NewRouter()
@@ -44,7 +46,7 @@ func (s *Server) StartServer() error {
 
 	srv := &http.Server{
 		Handler: r,
-		Addr:    fmt.Sprintf(":%d", s.port),
+		Addr:    fmt.Sprintf("%s:%d", s.addr, s.port),
 	}
 
 	return srv.ListenAndServe()


### PR DESCRIPTION
I need to be able to restrict metrics to 127.0.0.1 (long story short : running on Nomad, with the Consul Service Mesh, where all the security relies on services binding on 127.0.0.1 in their namespace)