### PR TITLE
Add workflow to create binary releases

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -5,14 +5,18 @@ on:
     types:
       - published
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [linux]
         arch: [386, amd64, arm64, arm]
-
     steps:
       - name: Check out the code
         uses: actions/checkout@v2
@@ -20,25 +24,29 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.22'
+          go-version: '1.24'
+
+      - name: Set release version variable
+        run: |
+          export RELEASE_TAG=$(jq -r '.release.tag_name' "$GITHUB_EVENT_PATH")
+          echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
 
       - name: Build the binary
-        env:
-          VERSION: ${{ github.ref_name }}
         run: |
           GOOS=${{ matrix.os }}
           GOARCH=${{ matrix.arch }}
-          go build -o proxmox_exporter-${VERSION}.${GOOS}-${GOARCH}
+          go build -o proxmox_exporter-${RELEASE_TAG}.${GOOS}-${GOARCH}
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: proxmox_exporter-${{ github.ref_name }}.${{ matrix.os }}-${{ matrix.arch }}
-          path: proxmox_exporter-${{ github.ref_name }}.${{ matrix.os }}-${{ matrix.arch }}
+          name: proxmox_exporter-${{ env.RELEASE_TAG }}.${{ matrix.os }}-${{ matrix.arch }}
+          path: proxmox_exporter-${{ env.RELEASE_TAG }}.${{ matrix.os }}-${{ matrix.arch }}
 
-      - name: Publish Release
-        uses: skx/github-action-publish-binaries@release-2.0
+      - name: Upload release binary
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: 'proxmox_exporter-*'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload \
+              ${RELEASE_TAG} \
+              proxmox_exporter-${RELEASE_TAG}.${{ matrix.os }}-${{ matrix.arch }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,44 @@
+name: Release Binaries
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [386, amd64, arm64, arm]
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.22'
+
+      - name: Build the binary
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          GOOS=${{ matrix.os }}
+          GOARCH=${{ matrix.arch }}
+          go build -o proxmox_exporter-${VERSION}.${GOOS}-${GOARCH}
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxmox_exporter-${{ github.ref_name }}.${{ matrix.os }}-${{ matrix.arch }}
+          path: proxmox_exporter-${{ github.ref_name }}.${{ matrix.os }}-${{ matrix.arch }}
+
+      - name: Publish Release
+        uses: skx/github-action-publish-binaries@release-2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: 'proxmox_exporter-*'


### PR DESCRIPTION
This adds workflow to publish built binary files. This is helpful for someone like me who doesn't want to run containers but instead run Proxmox exporter on the same host where Proxmox runs.