### PR TITLE
Accept "OK" in addition to "PASSED" as SMART result

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1 as build
+FROM golang:1 AS build
 
 WORKDIR /go/src/app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ proxmox_node_days_until_cert_expiration{cluster="prd",node="cmp3",subject="/CN=P
 proxmox_node_days_until_cert_expiration{cluster="prd",node="cmp3",subject="/CN=cmp3.gentoo-yo.ts.net"} 76
 proxmox_node_days_until_cert_expiration{cluster="prd",node="cmp3",subject="/OU=PVE Cluster Node/O=Proxmox Virtual Environment/CN=cmp3.local"} 702
 
-# HELP proxmox_node_disk_smart_status Disk SMART health status. (0=FAIL/Unknown,1=PASSED)
+# HELP proxmox_node_disk_smart_status Disk SMART health status. (0=FAIL/Unknown,1=PASSED/OK)
 # TYPE proxmox_node_disk_smart_status gauge
 proxmox_node_disk_smart_status{cluster="prd",devpath="/dev/nvme0n1",node="cmp1"} 1
 proxmox_node_disk_smart_status{cluster="prd",devpath="/dev/nvme0n1",node="cmp2"} 1

--- a/internal/prometheus/node.go
+++ b/internal/prometheus/node.go
@@ -114,7 +114,7 @@ func (c *Collector) collectDiskMetrics(ch chan<- prometheus.Metric, node proxmox
 	for _, disk := range disks.Data {
 		// Add disk health metric
 		status := 0.0
-		if strings.EqualFold(disk.Health, "PASSED") {
+		if strings.EqualFold(disk.Health, "PASSED") || strings.EqualFold(disk.Health, "OK") {
 			status = 1.0
 		}
 		ch <- prometheus.MustNewConstMetric(c.diskSmartHealth, prometheus.GaugeValue, status, node.Node, disk.DevPath)

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -126,7 +126,7 @@ func NewCollector() *Collector {
 
 		// Disk metrics
 		diskSmartHealth: prometheus.NewDesc(fqAddPrefix("node_disk_smart_status"),
-			"Disk SMART health status. (0=FAIL/Unknown,1=PASSED)",
+			"Disk SMART health status. (0=FAIL/Unknown,1=PASSED/OK)",
 			[]string{"node", "devpath"},
 			constLabels,
 		),


### PR DESCRIPTION
Dear @Starttoaster,

This is a great project, thank you very much!

I found out that my SAS SSDs return `OK` instead of `PASSED` when queried through the Proxmox API.

This here fixes that.

### Example outputs:

#### SAS SSD
```
# pvesh get /nodes/pve22/disks/smart --disk /dev/sdb
┌────────┬───────────────────────────────────────────────────┐
│ key    │ value                                             │
╞════════╪═══════════════════════════════════════════════════╡
│ health │ OK                                                │
├────────┼───────────────────────────────────────────────────┤
│ text   │                                                   │
│        │ Percentage used endurance indicator: 1%           │
│        │ Grown defects during certification = 0            │
│        │ Total blocks reassigned during format = 0         │
│        │ Total new blocks reassigned = 0                   │
│        │ Power on minutes since format = 2703794           │
│        │ Current Drive Temperature:     37 C               │
│        │ Drive Trip Temperature:        70 C               │
│        │                                                   │
│        │ Accumulated power on time, hours:minutes 45067:42 │
│        │ Manufactured in week 15 of year 2017              │
│        │ Specified cycle count over device lifetime:  0    │
│        │ Accumulated start-stop cycles:  1044              │
│        │ Elements in grown defect list: 0                  │
├────────┼───────────────────────────────────────────────────┤
│ type   │ text                                              │
└────────┴───────────────────────────────────────────────────┘
```

#### NVME
```
# pvesh get /nodes/pve22/disks/smart --disk /dev/nvme0n1
┌────────┬──────────────────────────────────────────────────────────┐
│ key    │ value                                                    │
╞════════╪══════════════════════════════════════════════════════════╡
│ health │ PASSED                                                   │
├────────┼──────────────────────────────────────────────────────────┤
│ text   │                                                          │
│        │ SMART/Health Information (NVMe Log 0x02)                 │
│        │ Critical Warning:                   0x00                 │
│        │ Temperature:                        40 Celsius           │
│        │ Available Spare:                    100%                 │
│        │ Available Spare Threshold:          10%                  │
│        │ Percentage Used:                    1%                   │
│        │ Data Units Read:                    15,965,841 [8.17 TB] │
│        │ Data Units Written:                 45,980,058 [23.5 TB] │
│        │ Host Read Commands:                 369,884,756          │
│        │ Host Write Commands:                678,147,408          │
│        │ Controller Busy Time:               1,144                │
│        │ Power Cycles:                       37                   │
│        │ Power On Hours:                     3,674                │
│        │ Unsafe Shutdowns:                   31                   │
│        │ Media and Data Integrity Errors:    0                    │
│        │ Error Information Log Entries:      34                   │
│        │ Warning  Comp. Temperature Time:    0                    │
│        │ Critical Comp. Temperature Time:    0                    │
├────────┼──────────────────────────────────────────────────────────┤
│ type   │ text                                                     │
└────────┴──────────────────────────────────────────────────────────┘
```