### PR TITLE
Allow using a Secret for sensitive configuration and allow changing builtin Prometheus rule thresholds

### DIFF
--- a/chart/proxmox-exporter/Chart.yaml
+++ b/chart/proxmox-exporter/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.2.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.7"
+appVersion: "v0.2.6"

--- a/chart/proxmox-exporter/Chart.yaml
+++ b/chart/proxmox-exporter/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.2.6"
+appVersion: "v0.2.7"

--- a/chart/proxmox-exporter/templates/deployment.yaml
+++ b/chart/proxmox-exporter/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: metrics
-              containerPort: {{ .Values.config.port }}
+              containerPort: {{ .Values.config.port | default 8080 }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -50,16 +50,27 @@ spec:
               value: '{{ .Values.config.log_level }}'
             - name: PROXMOX_EXPORTER_PROXMOX_API_INSECURE
               value: '{{ .Values.config.api_insecure }}'
+            {{- if .Values.config.endpoints }}
             - name: PROXMOX_EXPORTER_PROXMOX_ENDPOINTS
               value: '{{ .Values.config.endpoints }}'
+            {{- end }}
+            {{- if .Values.config.token }}
             - name: PROXMOX_EXPORTER_PROXMOX_TOKEN
               value: '{{ .Values.config.token }}'
+            {{- end }}
+            {{- if .Values.config.tokenID }}
             - name: PROXMOX_EXPORTER_PROXMOX_TOKEN_ID
               value: '{{ .Values.config.tokenID }}'
+            {{- end }}
             - name: PROXMOX_EXPORTER_SERVER_ADDR
-              value: '{{ .Values.config.addr }}'
+              value: '{{ .Values.config.addr | default "0.0.0.0" }}'
             - name: PROXMOX_EXPORTER_SERVER_PORT
-              value: '{{ .Values.config.port }}'
+              value: '{{ .Values.config.port | default 8080 }}'
+          {{- if and .Values.config.secretRef .Values.config.secretRef.name }}
+          envFrom:
+            - secretRef:
+                {{- toYaml .Values.config.secretRef | nindent 16 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/proxmox-exporter/templates/prometheusrule.yaml
+++ b/chart/proxmox-exporter/templates/prometheusrule.yaml
@@ -75,7 +75,7 @@ spec:
             summary: Proxmox certificate on node {{ printf "{{ $labels.node }}" }} is expiring in a week
             description: The certificate with subject {{ printf "{{ $labels.subject }}" }} on that node is expiring in {{ printf "{{ $value }}" }} days
           expr: |
-            proxmox_node_days_until_cert_expiration < 7
+            proxmox_node_days_until_cert_expiration < {{ .Values.prometheusRule.threshold_ProxmoxCertificateExpiring | default 7 }}
           for: 5m
           labels:
             severity: critical
@@ -84,7 +84,7 @@ spec:
             summary: Proxmox certificate on node {{ printf "{{ $labels.node }}" }} is expiring soon
             description: The certificate with subject {{ printf "{{ $labels.subject }}" }} on that node is expiring in {{ printf "{{ $value }}" }} days
           expr: |
-            proxmox_node_days_until_cert_expiration < 14
+            proxmox_node_days_until_cert_expiration < {{ .Values.prometheusRule.threshold_ProxmoxCertificateExpiringWarning | default 14 }}
           for: 5m
           labels:
             severity: warning
@@ -94,7 +94,7 @@ spec:
             summary: Proxmox storage volume {{ printf "{{ $labels.node }}" }}/{{ printf "{{ $labels.storage }}" }} nearly full
             description: Volume of type {{ printf "{{ $labels.type }}" }} is {{ printf "{{ $value }}" }}% full
           expr: |
-            100 * (sum by (storage,node) (proxmox_node_storage_used_bytes{shared="false"}) / sum by (storage,node) (proxmox_node_storage_total_bytes)) > 90
+            100 * (sum by (storage,node) (proxmox_node_storage_used_bytes{shared="false"}) / sum by (storage,node) (proxmox_node_storage_total_bytes)) > {{ .Values.prometheusRule.threshold_ProxmoxUnsharedStorageNearlyFull | default 90 }}
           for: 5m
           labels:
             severity: critical
@@ -103,7 +103,7 @@ spec:
             summary: Proxmox storage volume {{ printf "{{ $labels.node }}" }}/{{ printf "{{ $labels.storage }}" }} nearly full
             description: Volume of type {{ printf "{{ $labels.type }}" }} is {{ printf "{{ $value }}" }}% full
           expr: |
-            100 * (sum by (storage,node) (proxmox_node_storage_used_bytes{shared="false"}) / sum by (storage,node) (proxmox_node_storage_total_bytes)) > 80
+            100 * (sum by (storage,node) (proxmox_node_storage_used_bytes{shared="false"}) / sum by (storage,node) (proxmox_node_storage_total_bytes)) > {{ .Values.prometheusRule.threshold_ProxmoxUnsharedStorageFilling | default 80 }}
           for: 5m
           labels:
             severity: warning
@@ -113,7 +113,7 @@ spec:
             summary: Proxmox shared storage volume {{ printf "{{ $labels.storage }}" }} nearly full
             description: Volume of type {{ printf "{{ $labels.type }}" }} is {{ printf "{{ $value }}" }}% full
           expr: |
-            100 * (sum by (storage) (proxmox_node_storage_used_bytes{shared="true"}) / sum by (storage) (proxmox_node_storage_total_bytes)) > 90
+            100 * (sum by (storage) (proxmox_node_storage_used_bytes{shared="true"}) / sum by (storage) (proxmox_node_storage_total_bytes)) > {{ .Values.prometheusRule.threshold_ProxmoxSharedStorageNearlyFull | default 90 }}
           for: 5m
           labels:
             severity: critical
@@ -122,7 +122,7 @@ spec:
             summary: Proxmox shared storage volume {{ printf "{{ $labels.storage }}" }} nearly full
             description: Volume of type {{ printf "{{ $labels.type }}" }} is {{ printf "{{ $value }}" }}% full
           expr: |
-            100 * (sum by (storage) (proxmox_node_storage_used_bytes{shared="true"}) / sum by (storage) (proxmox_node_storage_total_bytes)) > 80
+            100 * (sum by (storage) (proxmox_node_storage_used_bytes{shared="true"}) / sum by (storage) (proxmox_node_storage_total_bytes)) > {{ .Values.prometheusRule.threshold_ProxmoxSharedStorageFilling | default 80 }}
           for: 5m
           labels:
             severity: warning
@@ -132,7 +132,7 @@ spec:
             summary: Proxmox node {{ printf "{{ $labels.node }}" }} has {{ printf "{{ $value }}" }}% of its CPU allocated to guests
             description: It is recommended to keep more of your node's CPU unallocated for use by PVE and other server applications your Proxmox node runs
           expr: |
-            100 * (proxmox_node_cpus_allocated / proxmox_node_cpus_total) > 90
+            100 * (proxmox_node_cpus_allocated / proxmox_node_cpus_total) > {{ .Values.prometheusRule.threshold_ProxmoxCPUAllocationHigh | default 90 }}
           for: 5m
           labels:
             severity: critical
@@ -141,7 +141,7 @@ spec:
             summary: Proxmox node {{ printf "{{ $labels.node }}" }} has {{ printf "{{ $value }}" }}% of its memory allocated to guests
             description: It is recommended to keep more of your node's memory unallocated for use by PVE and other server applications your Proxmox node runs
           expr: |
-            100 * (proxmox_node_memory_allocated_bytes / proxmox_node_memory_total_bytes) > 90
+            100 * (proxmox_node_memory_allocated_bytes / proxmox_node_memory_total_bytes) > {{ .Values.prometheusRule.threshold_ProxmoxMemoryAllocationHigh | default 90 }}
           for: 5m
           labels:
             severity: critical

--- a/chart/proxmox-exporter/values.yaml
+++ b/chart/proxmox-exporter/values.yaml
@@ -23,17 +23,28 @@ config:
 
   # Set to your actual API server URL(s). Can be one, or multiple separated by commas
   # Ex: https://x:8006/,https://y:8006/,https://z:8006/
-  endpoints: ''
+  # Ends up in PROXMOX_EXPORTER_PROXMOX_ENDPOINTS
+  # Can also be set via a Secret (see below)
+  # endpoints: ''
 
   # A Proxmox API token and token-ID. Needs to have at least the PVEAuditor role
-  token: ''
-  tokenID: ''
+  # Ends up in PROXMOX_EXPORTER_PROXMOX_TOKEN and PROXMOX_EXPORTER_PROXMOX_TOKEN_ID
+  # Can also be set via a Secret (see below)
+  # token: ''
+  # tokenID: ''
 
   # optional: Set this to the address you want the server to bind to (0.0.0.0 by default)
-  addr: '0.0.0.0'
-  # optional: Set to the port you want the server to listen on. 
+  # addr: '0.0.0.0'
+
+  # optional: Set to the port you want the server to listen on (8080 by default)
   # If you change this, change the service.port value too
-  port: '8080'
+  # port: '8080'
+
+  # optional: Name of a Secret containing additional environment variables
+  # All key-value pairs from the Secret will be available as environment variables
+  # Useful for setting PROXMOX_EXPORTER_PROXMOX_ENDPOINTS, PROXMOX_EXPORTER_PROXMOX_TOKEN and PROXMOX_EXPORTER_PROXMOX_TOKEN_ID
+  # secretRef:
+  #   name: ''
 
 serviceMonitor:
   enabled: false
@@ -55,6 +66,14 @@ prometheusRule:
 
   # Disable this to use your own rules provided in additionalRules
   enableBuiltinRules: true
+
+  # optional: Override individual thresholds for builtin rules
+  # threshold_ProxmoxUnsharedStorageNearlyFull: 90
+  # threshold_ProxmoxUnsharedStorageFilling: 80
+  # threshold_ProxmoxSharedStorageNearlyFull: 90
+  # threshold_ProxmoxSharedStorageFilling: 80
+  # threshold_ProxmoxCPUAllocationHigh: 90
+  # threshold_ProxmoxMemoryAllocationHigh: 90
 
   # A list of additional rules to provide to the PrometheusRule CR
   # additionalRules:


### PR DESCRIPTION
Dear @Starttoaster,

I didn't want to put my (read-only) token plaintext into helm values, so I added support to fetch env vars from a Secret (very similar to [this comment](https://github.com/Starttoaster/proxmox-exporter/issues/54#issuecomment-2557904970)).

Also I like to run my cluster hot and need to override the prometheus rule thresholds :)

Should be fully backwards compatible.

Let me know what you think about this approach.

Thanks!

### Example helm values
```
config:
  log_level: debug
  api_insecure: "false"
  secretRef:
    name: proxmox-exporter
serviceMonitor:
  enabled: true
prometheusRule:
  enabled: true
  threshold_ProxmoxUnsharedStorageNearlyFull: 95
  threshold_ProxmoxUnsharedStorageFilling: 95
  threshold_ProxmoxCPUAllocationHigh: 300
securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
    - ALL
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  runAsUser: 1000
  seccompProfile:
    type: RuntimeDefault
```

### Example secret
```
apiVersion: v1
kind: Secret
metadata:
  name: proxmox-exporter
  namespace: proxmox-exporter
stringData:
  PROXMOX_EXPORTER_PROXMOX_ENDPOINTS: https://1.2.3.4:8006/,https://2.3.4.5:8006/,https://3.4.5.6:8006/
  PROXMOX_EXPORTER_PROXMOX_TOKEN: e8f56392-a02b-4ed2-9ab9-4ea1deadbeef
  PROXMOX_EXPORTER_PROXMOX_TOKEN_ID: proxmox_exporter@pve!proxmox_exporter
```
